### PR TITLE
Add vagrant-dns plugin block

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Bridged networks make the machine appear as another physical device on
   # your network.
   #config.vm.network "public_network"
+  
+  # Use the vagrant-dns plugin, if available.
+  if RUBY_PLATFORM =~ /darwin/i
+    if Vagrant.has_plugin?("vagrant-dns")
+      config.dns.tld = "ubxd.dev"
+      config.dns.patterns = [/^.*ubxd.dev$/]
+    else
+      puts "installing the vagrant-dns plugin is recommended"
+      puts "see https://github.com/BerlinVagrant/vagrant-dns for more."
+    end
+  end
 
   # If true, then any SSH connections made will enable agent forwarding.
   # Default value: false


### PR DESCRIPTION
This update to the `Vagranfile` includes a block which utilises and configures the `vagrant-dns` plugin if present on the host system, and recommends its use if not.

Users can then browse to a vagrant ip address and port using a wildcard DNS pattern like  `*.ubxd.dev` in a browser running on the VM host machine.
